### PR TITLE
Fix: Convert /api/ endpoint to /api/v1/ endpoint

### DIFF
--- a/backend/apps/listings/serializers.py
+++ b/backend/apps/listings/serializers.py
@@ -17,7 +17,7 @@ class ListingImageSerializer(serializers.ModelSerializer):
         ]
 
 
-# Create listing — only used for POST /api/listings/
+# Create listing — only used for POST /api/v1/listings/
 class ListingCreateSerializer(serializers.ModelSerializer):
     images = serializers.ListField(
         child=serializers.ImageField(max_length=100000, allow_empty_file=False, use_url=False),
@@ -83,7 +83,7 @@ class ListingCreateSerializer(serializers.ModelSerializer):
         return listing
 
 
-# Detail page — GET /api/listings/<id>/
+# Detail page — GET /api/v1/listings/<id>/
 class ListingDetailSerializer(serializers.ModelSerializer):
     images = ListingImageSerializer(many=True, read_only=True)
     user_email = serializers.EmailField(source='user.email', read_only=True)
@@ -255,7 +255,7 @@ class ListingUpdateSerializer(serializers.ModelSerializer):
         return instance
 
 
-# Compact list — GET /api/listings/
+# Compact list — GET /api/v1/listings/
 class CompactListingSerializer(serializers.ModelSerializer):
     primary_image = serializers.SerializerMethodField()
 

--- a/backend/apps/listings/urls.py
+++ b/backend/apps/listings/urls.py
@@ -8,13 +8,13 @@ urlpatterns = router.urls
 """
     Following APIs are Supported:
 
-       METHOD       API Endpoints              Function                     Fields
+       METHOD       API Endpoints                  Function                     Fields
 
-    1. POST         /api/listings/             create a listing             category, title, description, price, status, location, images (optional, max 10)
-    2. GET          /api/listings/             list all listings            listing_id, category, title, price, status, primary_image
-    3. GET          /api/listings/<id>/        retrieve a single listing    listing_id, category, title, description, price, status, location, created_at, updated_at, images, user_email, user_netid
-    4. PUT/PATCH    /api/listings/<id>/        update a listing             category, title, description, price, status, location, new_images (optional), remove_image_ids (optional), update_images (optional)
-    5. DELETE       /api/listings/<id>/        delete a listing             (deletes listing and all associated images from S3)
+    1. POST         /api/v1/listings/             create a listing             category, title, description, price, status, location, images (optional, max 10)
+    2. GET          /api/v1/listings/             list all listings            listing_id, category, title, price, status, primary_image
+    3. GET          /api/v1/listings/<id>/        retrieve a single listing    listing_id, category, title, description, price, status, location, created_at, updated_at, images, user_email, user_netid
+    4. PUT/PATCH    /api/v1/listings/<id>/        update a listing             category, title, description, price, status, location, new_images (optional), remove_image_ids (optional), update_images (optional)
+    5. DELETE       /api/v1/listings/<id>/        delete a listing             (deletes listing and all associated images from S3)
 
     Image Management in Update (PUT/PATCH):
     - new_images: List of image files to upload (max 10 total images per listing)

--- a/backend/apps/listings/views.py
+++ b/backend/apps/listings/views.py
@@ -23,7 +23,7 @@ class ListingViewSet(
     ):
     """
     A viewset for creating listings.
-    Exposes a POST endpoint to /api/listings/.
+    Exposes a POST endpoint to /api/v1/listings/.
     Supports multipart/form-data for image uploads.
     """
     queryset = Listing.objects.all()

--- a/backend/apps/users/urls.py
+++ b/backend/apps/users/urls.py
@@ -10,6 +10,6 @@ urlpatterns = router.urls
 
        METHOD       API Endpoints              Function
 
-    1. POST         /api/auth/login/           Login or register user (auto-detects)
-    2. GET          /api/auth/me/              Get current authenticated user details
+    1. POST         /api/v1/auth/login/        Login or register user (auto-detects)
+    2. GET          /api/v1/auth/me/           Get current authenticated user details
 """

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -32,7 +32,7 @@ class AuthViewSet(viewsets.GenericViewSet):
         - First time: creates user and returns JWT
         - Subsequent times: validates password and returns JWT
 
-        POST /api/auth/login/
+        POST /api/v1/auth/login/
         """
         serializer = UserAuthSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -75,7 +75,7 @@ class AuthViewSet(viewsets.GenericViewSet):
         """
         Get current authenticated user's details
 
-        GET /api/auth/me/
+        GET /api/v1/auth/me/
         """
         serializer = UserDetailSerializer(request.user)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -18,7 +18,7 @@ from django.contrib import admin
 from django.urls import path, include
 
 urlpatterns = [
-    path('api/', include('apps.users.urls')),
-    path('api/', include('apps.listings.urls')),
+    path('api/v1/', include('apps.users.urls')),
+    path('api/v1/', include('apps.listings.urls')),
     path("admin/", admin.site.urls),
 ]


### PR DESCRIPTION
**Changes Made**

  1. Updated Main URL Configuration
  - Modified backend/core/urls.py to change URL patterns from api/ to api/v1/ for both users and listings endpoints

  2. Updated URL Documentation in Django Apps
  - Updated endpoint path documentation in backend/apps/users/urls.py and backend/apps/listings/urls.py from /api/ to /api/v1/

  3. Updated View Documentation
  - Modified docstrings in backend/apps/users/views.py and backend/apps/listings/views.py to reference /api/v1/ endpoints

  4. Updated Serializer Documentation
  - Updated comments in backend/apps/listings/serializers.py for all serializer classes to reference /api/v1/ endpoints