### PR TITLE
Fix: Add  the authentication part to manage listing's APIs

### DIFF
--- a/backend/apps/listings/urls.py
+++ b/backend/apps/listings/urls.py
@@ -8,13 +8,23 @@ urlpatterns = router.urls
 """
     Following APIs are Supported:
 
-       METHOD       API Endpoints              Function                     Fields
+       METHOD    AUTH    API Endpoints              Function                     Fields
 
-    1. POST         /api/listings/             create a listing             category, title, description, price, status, location, images (optional, max 10)
-    2. GET          /api/listings/             list all listings            listing_id, category, title, price, status, primary_image
-    3. GET          /api/listings/<id>/        retrieve a single listing    listing_id, category, title, description, price, status, location, created_at, updated_at, images, user_email, user_netid
-    4. PUT/PATCH    /api/listings/<id>/        update a listing             category, title, description, price, status, location, new_images (optional), remove_image_ids (optional), update_images (optional)
-    5. DELETE       /api/listings/<id>/        delete a listing             (deletes listing and all associated images from S3)
+    1. POST      Y       /api/listings/             create a listing             category, title, description, price, status, location, images (optional, max 10)
+    2. GET       N       /api/listings/             list all listings            listing_id, category, title, price, status, primary_image
+    3. GET       N       /api/listings/<id>/        retrieve a single listing    listing_id, category, title, description, price, status, location, created_at, updated_at, images, user_email, user_netid
+    4. PUT/PATCH Y*      /api/listings/<id>/        update a listing             category, title, description, price, status, location, new_images (optional), remove_image_ids (optional), update_images (optional)
+    5. DELETE    Y*      /api/listings/<id>/        delete a listing             (deletes listing and all associated images from S3)
+    6. GET       Y       /api/listings/user/        get user's listings          listing_id, category, title, price, status, primary_image
+
+    * AUTH Y with OWNERSHIP CHECK: User must be authenticated AND own the listing
+
+    Authentication:
+    - All authenticated endpoints require JWT token in Authorization header: "Bearer <token>"
+    - POST /api/listings/: User must be authenticated to create listings
+    - PUT/PATCH /api/listings/<id>/: User must be authenticated AND be the owner of the listing
+    - DELETE /api/listings/<id>/: User must be authenticated AND be the owner of the listing
+    - GET /api/listings/user/: User must be authenticated to view their own listings
 
     Image Management in Update (PUT/PATCH):
     - new_images: List of image files to upload (max 10 total images per listing)


### PR DESCRIPTION
**Changes Made**

  1) views.py
    - Added IsOwnerOrReadOnly permission class
    - Updated permissions to include IsAuthenticatedOrReadOnly and IsOwnerOrReadOnly
    - Added get_permissions() for user-specific endpoint authentication
    - Added perform_update() to prevent ownership changes
    - New endpoint: GET /api/listings/user/ for authenticated user's listings
  2) serializers.py
    - Added authentication validation in ListingCreateSerializer
    - Added authentication and ownership verification in ListingUpdateSerializer
    - Implemented dual-layer security (serializer + permission level)
  3) urls.py
    - Updated API docs with authentication requirements
    - Documented new GET /api/listings/user/ endpoint
    - Added JWT and ownership verification notes