### PR TITLE
fix(favicon): Favicon delivery follow-up

### DIFF
--- a/backend/.platform/hooks/postdeploy/90_sync_vite_assets.sh
+++ b/backend/.platform/hooks/postdeploy/90_sync_vite_assets.sh
@@ -38,8 +38,20 @@ else
   echo "[postdeploy][WARN] $BUILD_DIR/assets not found"
 fi
 
-if [ -f "$BUILD_DIR/vite.svg" ]; then
-  cp -f "$BUILD_DIR/vite.svg" "$STATIC_ROOT/vite.svg"
-fi
+# Favicon / app icons / manifest
+for f in \
+  favicon.ico \
+  favicon-16x16.png favicon-32x32.png favicon-48x48.png favicon-64x64.png \
+  favicon-128x128.png favicon-256x256.png \
+  apple-touch-icon.png \
+  android-chrome-192x192.png android-chrome-512x512.png \
+  manifest.webmanifest
+do
+  if [ -f "$BUILD_DIR/$f" ]; then
+    cp -f "$BUILD_DIR/$f" "$STATIC_ROOT/$f"
+  else
+    echo "[postdeploy][WARN] $BUILD_DIR/$f not found"
+  fi
+done
 
 echo "[postdeploy] Done."

--- a/backend/.platform/nginx/conf.d/elasticbeanstalk/favicons.conf
+++ b/backend/.platform/nginx/conf.d/elasticbeanstalk/favicons.conf
@@ -1,0 +1,16 @@
+add_header Cache-Control "no-cache, must-revalidate";
+
+location = /favicon.ico {
+    root /var/app/current/frontend_build;
+    try_files /favicon.ico =404;
+    access_log off;
+    log_not_found off;
+    default_type image/x-icon;
+}
+
+location ~ ^/(apple-touch-icon\.png|android-chrome-(192x192|512x512)\.png|favicon-(16x16|32x32|48x48|64x64|128x128|256x256)\.png|manifest\.webmanifest)$ {
+    root /var/app/current/frontend_build;
+    try_files $uri =404;
+    access_log off;
+    log_not_found off;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,14 +18,14 @@
     <link rel="canonical" href="http://nyu-marketplace-env.eba-vjpy9jfw.us-east-1.elasticbeanstalk.com" />
 
     <!-- Favicon / Icons -->
-    <link rel="icon" type="image/x-icon" href="/favicon.ico?v=1" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=1" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=1" />
-    <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png?v=1" />
-    <link rel="icon" type="image/png" sizes="64x64" href="/favicon-64x64.png?v=1" />
-    <link rel="icon" type="image/png" sizes="128x128" href="/favicon-128x128.png?v=1" />
-    <link rel="icon" type="image/png" sizes="256x256" href="/favicon-256x256.png?v=1" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=1" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico?v=2" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=2" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=2" />
+    <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png?v=2" />
+    <link rel="icon" type="image/png" sizes="64x64" href="/favicon-64x64.png?v=2" />
+    <link rel="icon" type="image/png" sizes="128x128" href="/favicon-128x128.png?v=2" />
+    <link rel="icon" type="image/png" sizes="256x256" href="/favicon-256x256.png?v=2" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=2" />
 
     <!-- PWA Manifest -->
     <link rel="manifest" href="/manifest.webmanifest" />


### PR DESCRIPTION
**Patch update (follow-up):**
- Serve favicon & app icons directly via Nginx (server context).
- Bypass SPA/Django rewrite for `/favicon.ico`, Apple/Android icons, and `manifest.webmanifest`.
- Add `Cache-Control: no-cache, must-revalidate` for `/favicon.ico` to fix Chrome bookmark caching.
- Postdeploy hook now syncs icons/manifest from `backend/frontend_build` to `staticfiles` and stops copying `vite.svg`.
