### PR TITLE
Fix #166 / Issues with delete listing 

### DIFF
--- a/backend/apps/listings/views.py
+++ b/backend/apps/listings/views.py
@@ -68,7 +68,8 @@ class ListingViewSet(
     Supports multipart/form-data for image uploads.
     """
 
-    queryset = Listing.objects.filter(status="active")
+    queryset = Listing.objects.all()
+
     permission_classes = [IsAuthenticatedOrReadOnly, IsOwnerOrReadOnly]
     parser_classes = [MultiPartParser, FormParser, JSONParser]
 
@@ -85,11 +86,14 @@ class ListingViewSet(
     def get_queryset(self):
         queryset = super().get_queryset()
 
+        # Only public list/search should be restricted to active listings
+        if self.action in ["list", "search"]:
+            queryset = queryset.filter(status="active")
+
         allowed_fields = {"created_at", "price", "title"}
         ordering_param = self.request.query_params.get("ordering")
 
         if ordering_param:
-            # any mistake if made at the end of the URL will be stripped
             ordering_param = ordering_param.strip()
             raw = ordering_param.lstrip("-")
             if raw not in allowed_fields:


### PR DESCRIPTION
### Summary
Fixes an issue where deleting some listings returned `404 Not Found` from `DELETE /api/v1/listings/<id>/` even though the listing existed and was visible under **My Listings**.

### Fix
- Changed `ListingViewSet` base queryset to:
  ```python
  queryset = Listing.objects.all()
-Applied status="active" filter only in get_queryset() for public actions (list, search).

-Kept existing permissions (IsAuthenticatedOrReadOnly, IsOwnerOrReadOnly) and ordering/prefetch logic.

### Testing

Deleted an active listing → ✅ success.

Changed a listing to a non-active status (e.g. sold) and deleted it → ✅ no 404, listing removed.

Confirmed:

GET /api/v1/listings/ still returns only active listings.

GET /api/v1/listings/user/ still returns all listings for the user.