### PR TITLE
Hotfix Main: Added deploy timestamp to Travis CI configuration to fix app version conflict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -270,7 +270,7 @@ jobs:
           bucket: "nyu-marketplace-dev-images"
           edge: true
           zip_file: deploy.zip
-          label: "prod-build-$TRAVIS_BUILD_NUMBER-$TRAVIS_COMMIT-$DEPLOY_TIMESTAMP"
+          label: "dev-build-$TRAVIS_BUILD_NUMBER-$TRAVIS_COMMIT-$DEPLOY_TIMESTAMP"
           wait_until_deployed: true
           wait_until_deployed_timeout: 900
           on:


### PR DESCRIPTION
This hotfix should fix `Application Version prod-build-165-xxx already exists. (Aws::ElasticBeanstalk::Errors::InvalidParameterValue)` when we manually trigger rebuild on Travis CI dashboard on the main/develop branch
