### PR TITLE
HotFix / #310 AWS Deployment Fails with AppRegistryNotReady (Circular Import)

### DIFF
--- a/backend/core/asgi.py
+++ b/backend/core/asgi.py
@@ -1,18 +1,18 @@
 import os
-import django
 from django.core.asgi import get_asgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "core.settings_local")
+
+django_asgi_app = get_asgi_application()
+
 from channels.routing import ProtocolTypeRouter, URLRouter
 from core.channels_jwt import JWTAuthMiddlewareStack
 from apps.chat.routing import websocket_urlpatterns
 
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "core.settings_local")
-django.setup()
-
-
 application = ProtocolTypeRouter(
     {
-        "http": get_asgi_application(),
+        "http": django_asgi_app,
         "websocket": JWTAuthMiddlewareStack(URLRouter(websocket_urlpatterns)),
     }
 )

--- a/backend/core/channels_jwt.py
+++ b/backend/core/channels_jwt.py
@@ -1,16 +1,18 @@
 from urllib.parse import parse_qs
 from channels.db import database_sync_to_async
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import AnonymousUser
 from django.db import close_old_connections
-from rest_framework_simplejwt.tokens import UntypedToken
-from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
-from rest_framework_simplejwt.backends import TokenBackend
-from rest_framework_simplejwt.settings import api_settings
 
 
 @database_sync_to_async
 def get_user(token_key):
+    # LAZY IMPORTS (Crucial for Daphne/ASGI)
+    from django.contrib.auth import get_user_model
+    from django.contrib.auth.models import AnonymousUser
+    from rest_framework_simplejwt.tokens import UntypedToken
+    from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
+    from rest_framework_simplejwt.backends import TokenBackend
+    from rest_framework_simplejwt.settings import api_settings
+
     try:
         UntypedToken(token_key)
 
@@ -40,6 +42,11 @@ class JWTAuthMiddleware:
         self.app = app
 
     async def __call__(self, scope, receive, send):
+        # --- LAZY IMPORT ---
+        from django.contrib.auth.models import AnonymousUser
+
+        # -------------------
+
         await database_sync_to_async(close_old_connections)()
 
         try:


### PR DESCRIPTION
## Summary
This PR resolves the `AppRegistryNotReady` crash occurring on AWS Elastic Beanstalk during deployment and configures the production environment to support real-time WebSockets via Daphne.

##  Key Changes

### 1. Fix Circular Import (Critical)
* **Refactored `channels_jwt.py`:** Moved Django model imports (`AnonymousUser`) inside the function scope (Lazy Loading). This prevents the server from crashing when Daphne imports the middleware before Django is fully initialized.
* **Updated `asgi.py`:** Reordered imports to ensure `django.setup()` runs before any app code is loaded.

### 2. Switch to ASGI
* **Updated `Procfile`:** Replaced `gunicorn` (WSGI) with `daphne` (ASGI) to enable WebSocket support.
    * `web: daphne -b 0.0.0.0 -p 5000 core.asgi:application`

### 3. Production Settings
* **Added `WhiteNoise`:** Configured middleware to serve static files (CSS/JS) since Daphne does not handle them natively.
* **Added `daphne`:** Explicitly added to `INSTALLED_APPS` in prod settings.
* **SSL & Headers:** Configured `SECURE_PROXY_SSL_HEADER` to trust AWS Load Balancer requests.

## Verification
* Validated locally by running `daphne` command to mimic production startup (no crash).
* Verified WebSocket connection via `InMemoryChannelLayer`.